### PR TITLE
upgrade longhorn to `v1.5.0-dev` from `v1.4.0-dev`

### DIFF
--- a/longhorn/ingress.yaml
+++ b/longhorn/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: "letsencrypt-prod"

--- a/longhorn/longhorn.yaml
+++ b/longhorn/longhorn.yaml
@@ -14,7 +14,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 ---
 # Source: longhorn/templates/serviceaccount.yaml
 apiVersion: v1
@@ -25,7 +25,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 ---
 # Source: longhorn/templates/default-setting.yaml
 apiVersion: v1
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 data:
   default-setting.yaml: |
     defaultSettings:
@@ -69,7 +69,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 data:
   storageclass.yaml: |
     kind: StorageClass
@@ -99,7 +99,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: backingimagedatasources.longhorn.io
 spec:
@@ -270,7 +270,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: backingimagemanagers.longhorn.io
 spec:
@@ -446,7 +446,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: backingimages.longhorn.io
 spec:
@@ -605,7 +605,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: backups.longhorn.io
 spec:
@@ -801,7 +801,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: backuptargets.longhorn.io
 spec:
@@ -984,7 +984,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: backupvolumes.longhorn.io
 spec:
@@ -1151,7 +1151,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: engineimages.longhorn.io
 spec:
@@ -1343,7 +1343,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: engines.longhorn.io
 spec:
@@ -1698,7 +1698,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: instancemanagers.longhorn.io
 spec:
@@ -1939,7 +1939,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: nodes.longhorn.io
 spec:
@@ -2183,7 +2183,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: orphans.longhorn.io
 spec:
@@ -2454,7 +2454,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: replicas.longhorn.io
 spec:
@@ -2671,7 +2671,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: settings.longhorn.io
 spec:
@@ -2762,7 +2762,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: sharemanagers.longhorn.io
 spec:
@@ -2877,7 +2877,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: snapshots.longhorn.io
 spec:
@@ -3004,7 +3004,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: supportbundles.longhorn.io
 spec:
@@ -3130,7 +3130,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: systembackups.longhorn.io
 spec:
@@ -3258,7 +3258,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: systemrestores.longhorn.io
 spec:
@@ -3360,7 +3360,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: volumes.longhorn.io
 spec:
@@ -3722,7 +3722,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     longhorn-manager: ""
   name: volumeattachments.longhorn.io
 spec:
@@ -3851,7 +3851,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -3917,7 +3917,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3935,7 +3935,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3952,7 +3952,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     app: longhorn-manager
   name: longhorn-backend
   namespace: longhorn-system
@@ -3973,7 +3973,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     app: longhorn-ui
   name: longhorn-frontend
   namespace: longhorn-system
@@ -3994,7 +3994,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     app: longhorn-conversion-webhook
   name: longhorn-conversion-webhook
   namespace: longhorn-system
@@ -4015,7 +4015,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     app: longhorn-admission-webhook
   name: longhorn-admission-webhook
   namespace: longhorn-system
@@ -4036,7 +4036,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     app: longhorn-recovery-backend
   name: longhorn-recovery-backend
   namespace: longhorn-system
@@ -4057,7 +4057,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
   name: longhorn-engine-manager
   namespace: longhorn-system
 spec:
@@ -4073,7 +4073,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
   name: longhorn-replica-manager
   namespace: longhorn-system
 spec:
@@ -4089,7 +4089,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     app: longhorn-manager
   name: longhorn-manager
   namespace: longhorn-system
@@ -4102,7 +4102,7 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.4.0-dev
+        app.kubernetes.io/version: v1.5.0-dev
         app: longhorn-manager
     spec:
       containers:
@@ -4194,7 +4194,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
 spec:
   replicas: 1
   selector:
@@ -4205,7 +4205,7 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.4.0-dev
+        app.kubernetes.io/version: v1.5.0-dev
         app: longhorn-driver-deployer
     spec:
       initContainers:
@@ -4260,7 +4260,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
+    app.kubernetes.io/version: v1.5.0-dev
     app: longhorn-ui
   name: longhorn-ui
   namespace: longhorn-system
@@ -4274,7 +4274,7 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.4.0-dev
+        app.kubernetes.io/version: v1.5.0-dev
         app: longhorn-ui
     spec:
       affinity:


### PR DESCRIPTION
trying to solve this error coming from longhorn-manager:

```
time="2023-07-31T08:11:53Z" level=info msg="Starting apiextensions.k8s.io/v1, Kind=CustomResourceDefinition controller"
time="2023-07-31T08:11:53Z" level=info msg="Starting apiregistration.k8s.io/v1, Kind=APIService controller"
time="2023-07-31T08:11:53Z" level=info msg="Started longhorn recovery-backend server"
W0731 08:11:53.992154       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
time="2023-07-31T08:11:53Z" level=info msg="Recovery-backend server is running at :9503"
time="2023-07-31T08:11:53Z" level=info msg="Checking if the upgrade path from v1.6.0-dev to v1.5.0-dev is supported"
time="2023-07-31T08:11:53Z" level=fatal msg="Error starting manager: failed to upgrade since downgrading from v1.6.0-dev to v1.5.0-dev is not supported"
```