### PR TITLE
Specify external TLS port

### DIFF
--- a/zitadel/zitadel_and_cockroachdb/zitadel_argocd_app.yaml
+++ b/zitadel/zitadel_and_cockroachdb/zitadel_argocd_app.yaml
@@ -46,6 +46,8 @@ spec:
     targetRevision: 11.1.5
     helm:
       values: |
+        configmapConfig:
+          ExternalPort: 443
         conf:
           singe-node: true
         statefulset:


### PR DESCRIPTION
When using vouch, Zitadel returns the following error:

> The requested redirect_uri is missing in the client configuration. If you have any questions, you may contact the administrator of the application.

According to: https://github.com/zitadel/zitadel/discussions/4048 , TLS mode is the culprit.

> This sounds to me like a problem with the tls mode. 


This add the suggested option from above