### PR TITLE
Add wireguard encryption options for cilium

### DIFF
--- a/alpha/cilium/README.md
+++ b/alpha/cilium/README.md
@@ -7,7 +7,13 @@ Cilium on Argo CD
   <img width="64" src="https://icons-for-free.com/iconfiles/png/512/argocd-1331550886883580947.png">
 <p>
 
-
 <p align="center">
 Deploy <a href="https://cilium.io/)">Cilium</a> to Kubernetes via an ArgoCD ApplicationSet.
 </p>
+
+___
+
+Features:
+- Deploy hubble dashboard behind vouch
+- Enables use of ebfp-dependant apps like Keda and Kepler
+- Encryption enabled via Wireguard integration. See https://docs.cilium.io/en/stable/security/network/encryption-wireguard/#enable-wireguard-in-cilium for more details.

--- a/alpha/cilium/README.md
+++ b/alpha/cilium/README.md
@@ -1,2 +1,13 @@
-# Cilium Argo CD ApplicationSet
-An ApplicationSet for using [Cilium](https://cilium.io/) in Kubernetes.
+<h1 align=center>
+Cilium on Argo CD
+</h1>
+
+<p align="center">
+  <img width="64" src="https://avatars.githubusercontent.com/u/21054566?s=200&v=4">
+  <img width="64" src="https://icons-for-free.com/iconfiles/png/512/argocd-1331550886883580947.png">
+<p>
+
+
+<p align="center">
+Deploy <a href="https://cilium.io/)">Cilium</a> to Kubernetes via an ArgoCD ApplicationSet.
+</p>

--- a/alpha/cilium/cilium_argocd_appset.yaml
+++ b/alpha/cilium/cilium_argocd_appset.yaml
@@ -42,6 +42,9 @@ spec:
           values: |
             operator:
               replicas: 1
+            encryption:
+              enabled: true
+              type: wireguard
             hubble:
               ui:
                 enabled: true


### PR DESCRIPTION
In order to use cilium as the CNI for k3s, we have to disable flannel. Since flannel is disabled we wont be able to use the flannel wireguard integration. This PR enables Cilium's own wireguard integration as a replacement.

https://docs.cilium.io/en/stable/security/network/encryption-wireguard/#enable-wireguard-in-cilium

