### PR TITLE
update renovate bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
   "argocd": {
     "fileMatch": ["\\.yaml$"]
   },


### PR DESCRIPTION
remove extra schema, doesnt seem to be needed?

renovate-config-validator
 INFO: Validating renovate.json
 INFO: Config validated successfully