### PR TITLE
Enable snippets

### DIFF
--- a/ingress-nginx/ingress-nginx_argocd_app.yaml
+++ b/ingress-nginx/ingress-nginx_argocd_app.yaml
@@ -12,6 +12,9 @@ spec:
     targetRevision: 4.8.3
     helm:
       releaseName: 'ingress-nginx'
+      values:
+        controller:
+          allowSnippetAnnotations: true
   destination:
     server: "https://kubernetes.default.svc"
     namespace: ingress-nginx

--- a/ingress-nginx/ingress-nginx_argocd_app.yaml
+++ b/ingress-nginx/ingress-nginx_argocd_app.yaml
@@ -12,7 +12,7 @@ spec:
     targetRevision: 4.8.3
     helm:
       releaseName: 'ingress-nginx'
-      values:
+      values: |
         controller:
           allowSnippetAnnotations: true
   destination:


### PR DESCRIPTION
Snippets were disabled by default starting in 1.9.0, we need them for vouch to work so adding that option to the helm chart