### PR TITLE
Fix SeaweedFS after latest updates and set CNPG Operator to do serverside apply

### DIFF
--- a/mastodon/small-hack/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/mastodon/small-hack/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -44,8 +44,8 @@ spec:
           values: |
             global:
               createClusterRole: true
-              serviceAccountName: "mastodon-seaweedfs"
-              loggingLevel: 1
+              imageName: chrislusf/seaweedfs
+              imagePullPolicy: IfNotPresent
               enableSecurity: false
               securityConfig:
                 jwtSigning:
@@ -53,24 +53,22 @@ spec:
                   volumeRead: false
                   filerWrite: false
                   filerRead: false
+              serviceAccountName: "mastodon-seaweedfs"
               certificates:
                 alphacrds: false
               monitoring:
                 enabled: false
-
-              # if enabled will use global.replicationPlacment and override master & filer defaultReplicaPlacement config
+                gatewayHost: null
+                gatewayPort: null
               enableReplication: false
-
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               replicationPlacment: "001"
               extraEnvironmentVars:
                 WEED_CLUSTER_DEFAULT: "sw"
                 WEED_CLUSTER_SW_MASTER: "seaweedfs-master.seaweedfs:9333"
                 WEED_CLUSTER_SW_FILER: "seaweedfs-filer-client.seaweedfs:8888"
-
+            image:
+              registry: ""
+              repository: ""
             master:
               enabled: true
               replicas: 1
@@ -78,89 +76,23 @@ spec:
               grpcPort: 19333
               metricsPort: 9327
               ipBind: "0.0.0.0"
-              volumePreallocate: false
-              volumeSizeLimitMB: 1000
-              # Prometheus push interval in seconds, default 15
+              loggingOverrideLevel: null
+              pulseSeconds: null
+              garbageThreshold: null
               metricsIntervalSec: 15
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               defaultReplication: "000"
-
-              # Disable http request, only gRpc operations are allowed
               disableHttp: false
-
               config: |-
                 # Enter any extra configuration for master.toml here.
                 # It may be be a multi-line string.
-
-              # can use ANY storage-class , example with local-path-provisioner
-              #  data:
-              #    type: "persistentVolumeClaim"
-              #    size: "24Ti"
-              #    storageClass: "local-path-provisioner"
               data:
                 type: "existingClaim"
                 claimName: "swfs-master-data"
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: master
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for master pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for master pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to master pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              extraEnvironmentVars:
-                WEED_MASTER_VOLUME_GROWTH_COPY_1: 7
-                WEED_MASTER_VOLUME_GROWTH_COPY_2: 6
-                WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
-                WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
-
-              # used to configure livenessProbe on master-server containers
-              #
+              logs:
+                type: "hostPath"
+                size: ""
+                storageClass: ""
+                hostPathPrefix: /storage
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -171,9 +103,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on master-server containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -181,10 +110,9 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
             volume:
               enabled: true
               port: 8080
@@ -192,87 +120,14 @@ spec:
               metricsPort: 9327
               ipBind: "0.0.0.0"
               replicas: 1
-
-              # limit file size to avoid out of memory, default 256mb
+              loggingOverrideLevel: null
               fileSizeLimitMB: null
-
-              # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
               minFreeSpacePercent: 7
-
-              data:
-                type: "existingClaim"
-                claimName: "swfs-volume-data"
-
-              idx:
-                type: "existingClaim"
-                claimName: "swfs-volume-idx"
-
-              # limit background compaction or copying speed in mega bytes per second
-              compactionMBps: "50"
-
-              # Directories to store data files. dir[,dir]... (default "/tmp")
-              dir: "/data"
-
-              # Directories to store index files. dir[,dir]... (default is the same as "dir")
-              dir_idx: null
-
-              # Maximum numbers of volumes, count[,count]...
-              # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-              maxVolumes: "0"
-
-              # Redirect moved or non-local volumes. (default proxy)
-              readMode: proxy
-
-              # Comma separated Ip addresses having write permission. No limit if empty.
-              whiteList: null
-
-              # Adjust jpg orientation when uploading.
-              imagesFixOrientation: false
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: volume
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-               beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-volume: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              # used to configure livenessProbe on volume-server containers
-              #
+              dataDirs:
+                - name: data
+                  type: "existingClaim"
+                  claimName: "swfs-volume-data"
+                  maxVolumes: 0
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -283,9 +138,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on volume-server containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -293,134 +145,25 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
             filer:
               enabled: true
               replicas: 1
-              loggingOverrideLevel: null
-              # turn off directory listing
-              disableDirListing: false
-              # split files larger than the limit, default 32
-              maxMB: null
-              # encrypt data on volume servers
+              port: 8888
+              grpcPort: 18888
+              metricsPort: 9327
               encryptVolumeData: true
-
-              # Whether proxy or redirect to volume server during file GET request
-              redirectOnRead: false
-
-              # Limit sub dir listing size (default 100000)
-              dirListLimit: 100000
-
-              # Disable http request, only gRpc operations are allowed
-              disableHttp: false
-
-              # Settings for configuring stateful storage of filer pods.
-              # enablePVC will create a pvc for filer for data persistence.
-              enablePVC: true
-
-              # storage should be set to the disk size of the attached volume.
-              storage: 25Gi
-
-              # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
-              storageClass: local-path
-
               data:
                 type: "existingClaim"
                 claimName: "swfs-filer-data"
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: filer
-                      topologyKey: kubernetes.io/hostname
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              # extraEnvVars is a list of extra enviroment variables to set with the stateful set.
-              extraEnvironmentVars:
-                WEED_MYSQL_ENABLED: "false"
-
-                # if you want to use leveldb2, then should enable "enablePVC". or you may lose your data.
-                WEED_LEVELDB2_ENABLED: "true"
-
-                # with http DELETE, by default the filer would check whether a folder is empty.
-                # recursive_delete will delete all sub folders and files, similar to "rm -Rf"
-                WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
-
-                # directories under this folder will be automatically creating a separate bucket
-                WEED_FILER_BUCKETS_FOLDER: "/buckets"
-
-              # used to configure livenessProbe on filer containers
-              #
-              livenessProbe:
-                enabled: true
-                httpGet:
-                  path: /
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 1
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # used to configure readinessProbe on filer containers
-              #
-              readinessProbe:
-                enabled: true
-                httpGet:
-                  path: /
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 1
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # this enables the filer and s3 which are both required to be deployed together
               s3:
                 enabled: true
+                port: 8333
+                httpsPort: 0
                 allowEmptyFolder: false
                 domainName: {{ .mastodon_s3_endpoint }}
-                # enable user & permission to s3 (need to inject to all services)
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
                 createBuckets:
@@ -428,18 +171,28 @@ spec:
                     anonymousRead: false
                   - name: mastodon-postgres
                     anonymousRead: false
+              livenessProbe:
+                enabled: true
+                httpGet:
+                  path: /
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 1
+                failureThreshold: 100
+                timeoutSeconds: 10
+              readinessProbe:
+                enabled: true
+                httpGet:
+                  path: /
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 2
+                failureThreshold: 100
+                timeoutSeconds: 10
             s3:
               enabled: false
-              ingress:
-                enabled: true
-                className: "nginx"
-                # host: false for "*" hostname
-                host: "{{ .mastodon_s3_endpoint }}"
-                # additional ingress annotations for the s3 endpoint
-                annotations:
-                  nginx.ingress.kubernetes.io/proxy-body-size: 1G
-                  cert-manager.io/cluster-issuer: {{ .global_cluster_issuer }}
-                tls:
                   - secretName: mastodon-seaweedfs-tls
                     hosts:
                       - "{{ .mastodon_s3_endpoint }}"

--- a/mastodon/small-hack/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/mastodon/small-hack/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -41,7 +41,7 @@ spec:
         chart: seaweedfs
         helm:
           releaseName: mastodon-seaweedfs
-          values: |
+          valuesObject:
             global:
               createClusterRole: true
               imageName: chrislusf/seaweedfs
@@ -163,7 +163,7 @@ spec:
                 port: 8333
                 httpsPort: 0
                 allowEmptyFolder: false
-                domainName: {{ .mastodon_s3_endpoint }}
+                domainName: '{{ .mastodon_s3_endpoint }}'
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
                 createBuckets:
@@ -195,4 +195,4 @@ spec:
               enabled: false
                   - secretName: mastodon-seaweedfs-tls
                     hosts:
-                      - "{{ .mastodon_s3_endpoint }}"
+                      - '{{ .mastodon_s3_endpoint }}'

--- a/matrix/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/matrix/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -44,33 +44,31 @@ spec:
           values: |
             global:
               createClusterRole: true
-              loggingLevel: 1
+              imageName: chrislusf/seaweedfs
+              imagePullPolicy: IfNotPresent
               enableSecurity: false
-              serviceAccountName: "matrix-seaweedfs"
               securityConfig:
                 jwtSigning:
                   volumeWrite: true
                   volumeRead: false
                   filerWrite: false
                   filerRead: false
+              serviceAccountName: "matrix-seaweedfs"
               certificates:
                 alphacrds: false
               monitoring:
                 enabled: false
-
-              # if enabled will use global.replicationPlacment and override master & filer defaultReplicaPlacement config
+                gatewayHost: null
+                gatewayPort: null
               enableReplication: false
-
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               replicationPlacment: "001"
               extraEnvironmentVars:
                 WEED_CLUSTER_DEFAULT: "sw"
                 WEED_CLUSTER_SW_MASTER: "seaweedfs-master.seaweedfs:9333"
                 WEED_CLUSTER_SW_FILER: "seaweedfs-filer-client.seaweedfs:8888"
-
+            image:
+              registry: ""
+              repository: ""
             master:
               enabled: true
               replicas: 1
@@ -78,89 +76,23 @@ spec:
               grpcPort: 19333
               metricsPort: 9327
               ipBind: "0.0.0.0"
-              volumePreallocate: false
-              volumeSizeLimitMB: 1000
-              # Prometheus push interval in seconds, default 15
+              loggingOverrideLevel: null
+              pulseSeconds: null
+              garbageThreshold: null
               metricsIntervalSec: 15
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               defaultReplication: "000"
-
-              # Disable http request, only gRpc operations are allowed
               disableHttp: false
-
               config: |-
                 # Enter any extra configuration for master.toml here.
                 # It may be be a multi-line string.
-
-              # can use ANY storage-class , example with local-path-provisioner
-              #  data:
-              #    type: "persistentVolumeClaim"
-              #    size: "24Ti"
-              #    storageClass: "local-path-provisioner"
               data:
                 type: "existingClaim"
                 claimName: "swfs-master-data"
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: master
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for master pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for master pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to master pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              extraEnvironmentVars:
-                WEED_MASTER_VOLUME_GROWTH_COPY_1: 7
-                WEED_MASTER_VOLUME_GROWTH_COPY_2: 6
-                WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
-                WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
-
-              # used to configure livenessProbe on master-server containers
-              #
+              logs:
+                type: "hostPath"
+                size: ""
+                storageClass: ""
+                hostPathPrefix: /storage
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -171,9 +103,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on master-server containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -181,10 +110,9 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
             volume:
               enabled: true
               port: 8080
@@ -192,87 +120,14 @@ spec:
               metricsPort: 9327
               ipBind: "0.0.0.0"
               replicas: 1
-
-              # limit file size to avoid out of memory, default 256mb
+              loggingOverrideLevel: null
               fileSizeLimitMB: null
-
-              # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
               minFreeSpacePercent: 7
-
-              data:
-                type: "existingClaim"
-                claimName: "swfs-volume-data"
-
-              idx:
-                type: "existingClaim"
-                claimName: "swfs-volume-idx"
-
-              # limit background compaction or copying speed in mega bytes per second
-              compactionMBps: "50"
-
-              # Directories to store data files. dir[,dir]... (default "/tmp")
-              dir: "/data"
-
-              # Directories to store index files. dir[,dir]... (default is the same as "dir")
-              dir_idx: null
-
-              # Maximum numbers of volumes, count[,count]...
-              # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-              maxVolumes: "0"
-
-              # Redirect moved or non-local volumes. (default proxy)
-              readMode: proxy
-
-              # Comma separated Ip addresses having write permission. No limit if empty.
-              whiteList: null
-
-              # Adjust jpg orientation when uploading.
-              imagesFixOrientation: false
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: volume
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-               beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-volume: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              # used to configure livenessProbe on volume-server containers
-              #
+              dataDirs:
+                - name: data
+                  type: "existingClaim"
+                  claimName: "swfs-volume-data"
+                  maxVolumes: 0
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -283,9 +138,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on volume-server containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -293,134 +145,25 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
             filer:
               enabled: true
               replicas: 1
-              loggingOverrideLevel: null
-              # turn off directory listing
-              disableDirListing: false
-              # split files larger than the limit, default 32
-              maxMB: null
-              # encrypt data on volume servers
+              port: 8888
+              grpcPort: 18888
+              metricsPort: 9327
               encryptVolumeData: true
-
-              # Whether proxy or redirect to volume server during file GET request
-              redirectOnRead: false
-
-              # Limit sub dir listing size (default 100000)
-              dirListLimit: 100000
-
-              # Disable http request, only gRpc operations are allowed
-              disableHttp: false
-
-              # Settings for configuring stateful storage of filer pods.
-              # enablePVC will create a pvc for filer for data persistence.
-              enablePVC: true
-
-              # storage should be set to the disk size of the attached volume.
-              storage: 25Gi
-
-              # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
-              storageClass: local-path
-
               data:
                 type: "existingClaim"
                 claimName: "swfs-filer-data"
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: filer
-                      topologyKey: kubernetes.io/hostname
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              # extraEnvVars is a list of extra enviroment variables to set with the stateful set.
-              extraEnvironmentVars:
-                WEED_MYSQL_ENABLED: "false"
-
-                # if you want to use leveldb2, then should enable "enablePVC". or you may lose your data.
-                WEED_LEVELDB2_ENABLED: "true"
-
-                # with http DELETE, by default the filer would check whether a folder is empty.
-                # recursive_delete will delete all sub folders and files, similar to "rm -Rf"
-                WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
-
-                # directories under this folder will be automatically creating a separate bucket
-                WEED_FILER_BUCKETS_FOLDER: "/buckets"
-
-              # used to configure livenessProbe on filer containers
-              #
-              livenessProbe:
-                enabled: true
-                httpGet:
-                  path: /
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 1
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # used to configure readinessProbe on filer containers
-              #
-              readinessProbe:
-                enabled: true
-                httpGet:
-                  path: /
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 1
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # this enables the filer and s3 which are both required to be deployed together
               s3:
                 enabled: true
+                port: 8333
+                httpsPort: 0
                 allowEmptyFolder: false
-                domainName: {{ .matrix_s3_endpoint }}
-                # enable user & permission to s3 (need to inject to all services)
+                domainName: "{{ .matrix_s3_endpoint }}"
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
                 createBuckets:
@@ -428,18 +171,25 @@ spec:
                     anonymousRead: false
                   - name: matrix-postgres
                     anonymousRead: false
+              livenessProbe:
+                enabled: true
+                httpGet:
+                  path: /
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 1
+                failureThreshold: 100
+                timeoutSeconds: 10
+              readinessProbe:
+                enabled: true
+                httpGet:
+                  path: /
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 2
+                failureThreshold: 100
+                timeoutSeconds: 10
             s3:
               enabled: false
-              ingress:
-                enabled: true
-                className: "nginx"
-                # host: false for "*" hostname
-                host: "{{ .matrix_s3_endpoint }}"
-                # additional ingress annotations for the s3 endpoint
-                annotations:
-                  nginx.ingress.kubernetes.io/proxy-body-size: 1G
-                  cert-manager.io/cluster-issuer: {{ .global_cluster_issuer }}
-                tls:
-                  - secretName: matrix-seaweedfs-tls
-                    hosts:
-                      - "{{ .matrix_s3_endpoint }}"

--- a/matrix/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/matrix/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -41,7 +41,7 @@ spec:
         chart: seaweedfs
         helm:
           releaseName: matrix-seaweedfs
-          values: |
+          valuesObject:
             global:
               createClusterRole: true
               imageName: chrislusf/seaweedfs
@@ -163,7 +163,7 @@ spec:
                 port: 8333
                 httpsPort: 0
                 allowEmptyFolder: false
-                domainName: "{{ .matrix_s3_endpoint }}"
+                domainName: '{{ .matrix_s3_endpoint }}'
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
                 createBuckets:

--- a/nextcloud/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/nextcloud/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -45,8 +45,8 @@ spec:
           valuesObject:
             global:
               createClusterRole: true
-              serviceAccountName: "nextcloud-seaweedfs"
-              loggingLevel: 1
+              imageName: chrislusf/seaweedfs
+              imagePullPolicy: IfNotPresent
               enableSecurity: false
               securityConfig:
                 jwtSigning:
@@ -54,24 +54,22 @@ spec:
                   volumeRead: false
                   filerWrite: false
                   filerRead: false
+              serviceAccountName: "nextcloud-seaweedfs"
               certificates:
                 alphacrds: false
               monitoring:
                 enabled: false
-
-              # if enabled will use global.replicationPlacment and override master & filer defaultReplicaPlacement config
+                gatewayHost: null
+                gatewayPort: null
               enableReplication: false
-
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               replicationPlacment: "001"
               extraEnvironmentVars:
                 WEED_CLUSTER_DEFAULT: "sw"
                 WEED_CLUSTER_SW_MASTER: "seaweedfs-master.seaweedfs:9333"
                 WEED_CLUSTER_SW_FILER: "seaweedfs-filer-client.seaweedfs:8888"
-
+            image:
+              registry: ""
+              repository: ""
             master:
               enabled: true
               replicas: 1
@@ -79,89 +77,23 @@ spec:
               grpcPort: 19333
               metricsPort: 9327
               ipBind: "0.0.0.0"
-              volumePreallocate: false
-              volumeSizeLimitMB: 1000
-              # Prometheus push interval in seconds, default 15
+              loggingOverrideLevel: null
+              pulseSeconds: null
+              garbageThreshold: null
               metricsIntervalSec: 15
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               defaultReplication: "000"
-
-              # Disable http request, only gRpc operations are allowed
               disableHttp: false
-
               config: |-
                 # Enter any extra configuration for master.toml here.
                 # It may be be a multi-line string.
-
-              # can use ANY storage-class , example with local-path-provisioner
-              #  data:
-              #    type: "persistentVolumeClaim"
-              #    size: "24Ti"
-              #    storageClass: "local-path-provisioner"
               data:
                 type: "existingClaim"
                 claimName: "swfs-master-data"
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: master
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for master pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for master pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to master pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              extraEnvironmentVars:
-                WEED_MASTER_VOLUME_GROWTH_COPY_1: 7
-                WEED_MASTER_VOLUME_GROWTH_COPY_2: 6
-                WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
-                WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
-
-              # used to configure livenessProbe on master-server containers
-              #
+              logs:
+                type: "hostPath"
+                size: ""
+                storageClass: ""
+                hostPathPrefix: /storage
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -172,9 +104,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on master-server containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -182,10 +111,9 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
             volume:
               enabled: true
               port: 8080
@@ -193,87 +121,14 @@ spec:
               metricsPort: 9327
               ipBind: "0.0.0.0"
               replicas: 1
-
-              # limit file size to avoid out of memory, default 256mb
+              loggingOverrideLevel: null
               fileSizeLimitMB: null
-
-              # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
               minFreeSpacePercent: 7
-
-              data:
-                type: "existingClaim"
-                claimName: "swfs-volume-data"
-
-              idx:
-                type: "existingClaim"
-                claimName: "swfs-volume-idx"
-
-              # limit background compaction or copying speed in mega bytes per second
-              compactionMBps: "50"
-
-              # Directories to store data files. dir[,dir]... (default "/tmp")
-              dir: "/data"
-
-              # Directories to store index files. dir[,dir]... (default is the same as "dir")
-              dir_idx: null
-
-              # Maximum numbers of volumes, count[,count]...
-              # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-              maxVolumes: "0"
-
-              # Redirect moved or non-local volumes. (default proxy)
-              readMode: proxy
-
-              # Comma separated Ip addresses having write permission. No limit if empty.
-              whiteList: null
-
-              # Adjust jpg orientation when uploading.
-              imagesFixOrientation: false
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: volume
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-               beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-volume: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              # used to configure livenessProbe on volume-server containers
-              #
+              dataDirs:
+                - name: data
+                  type: "existingClaim"
+                  claimName: "swfs-volume-data"
+                  maxVolumes: 0
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -284,9 +139,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on volume-server containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -294,104 +146,30 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
             filer:
               enabled: true
               replicas: 1
-              loggingOverrideLevel: null
-              # turn off directory listing
-              disableDirListing: false
-              # split files larger than the limit, default 32
-              maxMB: null
-              # encrypt data on volume servers
+              port: 8888
+              grpcPort: 18888
+              metricsPort: 9327
               encryptVolumeData: true
-
-              # Whether proxy or redirect to volume server during file GET request
-              redirectOnRead: false
-
-              # Limit sub dir listing size (default 100000)
-              dirListLimit: 100000
-
-              # Disable http request, only gRpc operations are allowed
-              disableHttp: false
-
-              # Settings for configuring stateful storage of filer pods.
-              # enablePVC will create a pvc for filer for data persistence.
-              enablePVC: true
-
-              # storage should be set to the disk size of the attached volume.
-              storage: 25Gi
-
-              # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
-              storageClass: local-path
-
               data:
                 type: "existingClaim"
                 claimName: "swfs-filer-data"
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: filer
-                      topologyKey: kubernetes.io/hostname
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              # extraEnvVars is a list of extra enviroment variables to set with the stateful set.
-              extraEnvironmentVars:
-                WEED_MYSQL_ENABLED: "false"
-
-                # if you want to use leveldb2, then should enable "enablePVC". or you may lose your data.
-                WEED_LEVELDB2_ENABLED: "true"
-
-                # with http DELETE, by default the filer would check whether a folder is empty.
-                # recursive_delete will delete all sub folders and files, similar to "rm -Rf"
-                WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
-
-                # directories under this folder will be automatically creating a separate bucket
-                WEED_FILER_BUCKETS_FOLDER: "/buckets"
-
-              # used to configure livenessProbe on filer containers
-              #
+              s3:
+                enabled: true
+                port: 8333
+                httpsPort: 0
+                allowEmptyFolder: false
+                domainName: '{{ .nextcloud_s3_endpoint }}'
+                enableAuth: true
+                existingConfigSecret: seaweedfs-s3-secret
+                createBuckets:
+                  - name: zitadel-postgres
+                    anonymousRead: false
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -402,9 +180,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on filer containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -412,35 +187,8 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # this enables the filer and s3 which are both required to be deployed together
-              s3:
-                enabled: true
-                allowEmptyFolder: false
-                domainName: '{{ .nextcloud_s3_endpoint }}'
-                # enable user & permission to s3 (need to inject to all services)
-                enableAuth: true
-                existingConfigSecret: seaweedfs-s3-secret
-                createBuckets:
-                  - name: nextcloud-data
-                    anonymousRead: false
-                  - name: nextcloud-postgres
-                    anonymousRead: false
-
             s3:
               enabled: false
-              ingress:
-                enabled: true
-                className: "nginx"
-                # host: false for "*" hostname
-                host: '{{ .nextcloud_s3_endpoint }}'
-                annotations:
-                  nginx.ingress.kubernetes.io/proxy-body-size: 1G
-                  cert-manager.io/cluster-issuer: '{{ .global_cluster_issuer }}'
-                tls:
-                  - secretName: nextcloud-seaweedfs-tls
-                    hosts:
-                      - '{{ .nextcloud_s3_endpoint }}'

--- a/postgres/operators/cloud-native-postgres/cnpg_operator_argocd_app.yaml
+++ b/postgres/operators/cloud-native-postgres/cnpg_operator_argocd_app.yaml
@@ -14,7 +14,7 @@ spec:
   syncPolicy:
     syncOptions:
       - ApplyOutOfSyncOnly=true
-      - Replace=true
+      - ServerSideApply=true
     automated:
       prune: true
       selfHeal: true

--- a/seaweedfs/app_of_apps/seaweedfs_argocd_appset.yaml
+++ b/seaweedfs/app_of_apps/seaweedfs_argocd_appset.yaml
@@ -52,160 +52,55 @@ spec:
           values: |
             global:
               createClusterRole: true
-              loggingLevel: 1
+              imageName: chrislusf/seaweedfs
+              imagePullPolicy: IfNotPresent
               enableSecurity: false
-              serviceAccountName: "seaweedfs-core"
               securityConfig:
                 jwtSigning:
                   volumeWrite: true
                   volumeRead: false
                   filerWrite: false
                   filerRead: false
+              serviceAccountName: "seaweedfs"
               certificates:
                 alphacrds: false
               monitoring:
                 enabled: false
                 gatewayHost: null
                 gatewayPort: null
-
-              # if enabled will use global.replicationPlacment and override master & filer defaultReplicaPlacement config
               enableReplication: false
-
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               replicationPlacment: "001"
               extraEnvironmentVars:
                 WEED_CLUSTER_DEFAULT: "sw"
                 WEED_CLUSTER_SW_MASTER: "seaweedfs-master.seaweedfs:9333"
                 WEED_CLUSTER_SW_FILER: "seaweedfs-filer-client.seaweedfs:8888"
-
+            image:
+              registry: ""
+              repository: ""
             master:
               enabled: true
-              repository: null
-              imageName: null
-              imageTag: null
-              imageOverride: null
-              restartPolicy: null
               replicas: 1
               port: 9333
               grpcPort: 19333
               metricsPort: 9327
               ipBind: "0.0.0.0"
-              volumePreallocate: false
-              volumeSizeLimitMB: 1000
               loggingOverrideLevel: null
-              # number of seconds between heartbeats, default 5
               pulseSeconds: null
-              # threshold to vacuum and reclaim spaces, default 0.3 (30%)
               garbageThreshold: null
-              # Prometheus push interval in seconds, default 15
               metricsIntervalSec: 15
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               defaultReplication: "000"
-
-              # Disable http request, only gRpc operations are allowed
               disableHttp: false
-
               config: |-
                 # Enter any extra configuration for master.toml here.
                 # It may be be a multi-line string.
-
-              # can use ANY storage-class , example with local-path-provisioner
-              #  data:
-              #    type: "persistentVolumeClaim"
-              #    size: "24Ti"
-              #    storageClass: "local-path-provisioner"
               data:
                 type: "existingClaim"
                 claimName: "swfs-master-data"
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Resource requests, limits, etc. for the master cluster placement. This
-              # should map directly to the value of the resources field for a PodSpec,
-              # formatted as a multi-line string. By default no direct resource request
-              # is made.
-              resources: null
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: master
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for master pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for master pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to master pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-                className: "nginx"
-                # host: false for "*" hostname
-                host: "master.seaweedfs.local"
-                annotations: |
-                  nginx.ingress.kubernetes.io/auth-type: "basic"
-                  nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
-                  nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Master'
-                  nginx.ingress.kubernetes.io/service-upstream: "true"
-                  nginx.ingress.kubernetes.io/rewrite-target: /$1
-                  nginx.ingress.kubernetes.io/use-regex: "true"
-                  nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
-                  nginx.ingress.kubernetes.io/ssl-redirect: "false"
-                  nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-                  nginx.ingress.kubernetes.io/configuration-snippet: |
-                    sub_filter '<head>' '<head> <base href="/sw-master/">'; #add base url
-                    sub_filter '="/' '="./';                                #make absolute paths to relative
-                    sub_filter '=/' '=./';
-                    sub_filter '/seaweedfsstatic' './seaweedfsstatic';
-                    sub_filter_once off;
-
-              extraEnvironmentVars:
-                WEED_MASTER_VOLUME_GROWTH_COPY_1: 7
-                WEED_MASTER_VOLUME_GROWTH_COPY_2: 6
-                WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
-                WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
-
-              # used to configure livenessProbe on master-server containers
-              #
+              logs:
+                type: "hostPath"
+                size: ""
+                storageClass: ""
+                hostPathPrefix: /storage
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -216,9 +111,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on master-server containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -226,122 +118,24 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
             volume:
               enabled: true
-              repository: null
-              imageName: null
-              imageTag: null
-              imageOverride: null
-              restartPolicy: null
               port: 8080
               grpcPort: 18080
               metricsPort: 9327
               ipBind: "0.0.0.0"
               replicas: 1
               loggingOverrideLevel: null
-
-              # number of seconds between heartbeats, must be smaller than or equal to the master's setting
-              pulseSeconds: null
-
-              # Choose [memory|leveldb|leveldbMedium|leveldbLarge] mode for memory~performance balance., default memory
-              index: null
-
-              # limit file size to avoid out of memory, default 256mb
               fileSizeLimitMB: null
-
-              # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
               minFreeSpacePercent: 7
-
               dataDirs:
-              - name: data1
-                type: "existingClaim"
-                claimName: "swfs-volume-data"
-                maxVolumes: 0
-
-              idx: ""
-
-              # limit background compaction or copying speed in mega bytes per second
-              compactionMBps: "50"
-
-              # Directories to store data files. dir[,dir]... (default "/tmp")
-              dir: "/data"
-
-              # Directories to store index files. dir[,dir]... (default is the same as "dir")
-              dir_idx: null
-
-              # Maximum numbers of volumes, count[,count]...
-              # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-              maxVolumes: "0"
-
-              # Volume server's rack name
-              rack: null
-
-              # Volume server's data center name
-              dataCenter: null
-
-              # Redirect moved or non-local volumes. (default proxy)
-              readMode: proxy
-
-              # Comma separated Ip addresses having write permission. No limit if empty.
-              whiteList: null
-
-              # Adjust jpg orientation when uploading.
-              imagesFixOrientation: false
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: volume
-                      topologyKey: kubernetes.io/hostname
-
-              # Resource requests, limits, etc. for the server cluster placement. This
-              # should map directly to the value of the resources field for a PodSpec,
-              # formatted as a multi-line string. By default no direct resource request
-              # is made.
-              resources: null
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-               beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-volume: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              # used to configure livenessProbe on volume-server containers
-              #
+                - name: data
+                  type: "existingClaim"
+                  claimName: "swfs-volume-data"
+                  maxVolumes: 0
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -351,10 +145,7 @@ spec:
                 periodSeconds: 2
                 successThreshold: 1
                 failureThreshold: 100
-                timeoutSeconds: 30
-
-              # used to configure readinessProbe on volume-server containers
-              #
+                timeoutSeconds: 10
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -362,144 +153,27 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
-                timeoutSeconds: 30
-
+                timeoutSeconds: 10
             filer:
               enabled: true
               replicas: 1
               port: 8888
               grpcPort: 18888
               metricsPort: 9327
-              loggingOverrideLevel: null
-              filerGroup: ""
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
-              defaultReplicaPlacement: "000"
-              # turn off directory listing
-              disableDirListing: false
-              # split files larger than the limit, default 32
-              maxMB: null
-              # encrypt data on volume servers
               encryptVolumeData: true
-
-              # Whether proxy or redirect to volume server during file GET request
-              redirectOnRead: false
-
-              # Limit sub dir listing size (default 100000)
-              dirListLimit: 100000
-
-              # Disable http request, only gRpc operations are allowed
-              disableHttp: false
-
-              # Settings for configuring stateful storage of filer pods.
-              # enablePVC will create a pvc for filer for data persistence.
-              enablePVC: true
-
-              # storage should be set to the disk size of the attached volume.
-              storage: 25Gi
-
-              # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
-              storageClass: local-path
-
               data:
                 type: "existingClaim"
                 claimName: "swfs-filer-data"
-
-              initContainers: ""
-
-              extraVolumes: ""
-              extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: filer
-                      topologyKey: kubernetes.io/hostname
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              updatePartition: 0
-
-              # Resource requests, limits, etc. for the server cluster placement. This
-              # should map directly to the value of the resources field for a PodSpec,
-              # formatted as a multi-line string. By default no direct resource request
-              # is made.
-              resources: null
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
-
-              ingress:
-                enabled: false
-                className: "nginx"
-                # host: false for "*" hostname
-                host: "seaweedfs.cluster.local"
-                annotations: |
-                  nginx.ingress.kubernetes.io/backend-protocol: GRPC
-                  nginx.ingress.kubernetes.io/auth-type: "basic"
-                  nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
-                  nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
-                  nginx.ingress.kubernetes.io/service-upstream: "true"
-                  nginx.ingress.kubernetes.io/rewrite-target: /$1
-                  nginx.ingress.kubernetes.io/use-regex: "true"
-                  nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
-                  nginx.ingress.kubernetes.io/ssl-redirect: "false"
-                  nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-                  nginx.ingress.kubernetes.io/configuration-snippet: |
-                    sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
-                    sub_filter '="/' '="./';                               #make absolute paths to relative
-                    sub_filter '=/' '=./';
-                    sub_filter '/seaweedfsstatic' './seaweedfsstatic';
-                    sub_filter_once off;
-
-              # extraEnvVars is a list of extra enviroment variables to set with the stateful set.
-              extraEnvironmentVars:
-                WEED_MYSQL_ENABLED: "false"
-
-                # if you want to use leveldb2, then should enable "enablePVC". or you may lose your data.
-                WEED_LEVELDB2_ENABLED: "true"
-
-                # with http DELETE, by default the filer would check whether a folder is empty.
-                # recursive_delete will delete all sub folders and files, similar to "rm -Rf"
-                WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
-
-                # directories under this folder will be automatically creating a separate bucket
-                WEED_FILER_BUCKETS_FOLDER: "/buckets"
-
-              # used to configure livenessProbe on filer containers
-              #
+              s3:
+                enabled: true
+                port: 8333
+                httpsPort: 0
+                allowEmptyFolder: false
+                domainName: "{{ .seaweedfs_s3_endpoint }}"
+                enableAuth: true
+                existingConfigSecret: seaweedfs-s3-secret
               livenessProbe:
                 enabled: true
                 httpGet:
@@ -510,9 +184,6 @@ spec:
                 successThreshold: 1
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # used to configure readinessProbe on filer containers
-              #
               readinessProbe:
                 enabled: true
                 httpGet:
@@ -520,40 +191,8 @@ spec:
                   scheme: HTTP
                 initialDelaySeconds: 10
                 periodSeconds: 2
-                successThreshold: 1
+                successThreshold: 2
                 failureThreshold: 100
                 timeoutSeconds: 10
-
-              # secret env variables
-              secretExtraEnvironmentVars: []
-                # WEED_POSTGRES_USERNAME:
-                #   secretKeyRef:
-                #     name: postgres-credentials
-                #     key: username
-                # WEED_POSTGRES_PASSWORD:
-                #   secretKeyRef:
-                #     name: postgres-credentials
-                #     key: password
-
-              # this enables the filer and s3 which are both required to be deployed together
-              s3:
-                enabled: true
-                port: 8333
-                # add additional https port
-                httpsPort: 0
-                allowEmptyFolder: false
-                domainName: "{{ .seaweedfs_s3_endpoint }}"
-                # enable user & permission to s3 (need to inject to all services)
-                enableAuth: true
-                existingConfigSecret: seaweedfs-s3-secret
-                auditLogConfig: {}
-                # You may specify buckets to be created during the install process.
-                # Buckets may be exposed publicly by setting `anonymousRead` to `true`
-                # createBuckets:
-                #   - name: bucket-a
-                #     anonymousRead: true
-                #   - name: bucket-b
-                #     anonymousRead: false
-    
             s3:
               enabled: false

--- a/seaweedfs/app_of_apps/seaweedfs_argocd_appset.yaml
+++ b/seaweedfs/app_of_apps/seaweedfs_argocd_appset.yaml
@@ -49,7 +49,7 @@ spec:
         chart: seaweedfs
         helm:
           releaseName: seaweedfs
-          values: |
+          valuesObject:
             global:
               createClusterRole: true
               imageName: chrislusf/seaweedfs
@@ -171,7 +171,7 @@ spec:
                 port: 8333
                 httpsPort: 0
                 allowEmptyFolder: false
-                domainName: "{{ .seaweedfs_s3_endpoint }}"
+                domainName: '{{ .seaweedfs_s3_endpoint }}'
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
               livenessProbe:

--- a/zitadel/app_of_apps/s3_provider_argocd_appset.yaml
+++ b/zitadel/app_of_apps/s3_provider_argocd_appset.yaml
@@ -36,4 +36,4 @@ spec:
       source:
         repoURL: https://github.com/small-hack/argocd-apps.git
         path: zitadel/storage/{{ .zitadel_s3_provider }}/
-        targetRevision: fix/zitadel-s3
+        targetRevision: main

--- a/zitadel/app_of_apps/s3_provider_argocd_appset.yaml
+++ b/zitadel/app_of_apps/s3_provider_argocd_appset.yaml
@@ -36,4 +36,4 @@ spec:
       source:
         repoURL: https://github.com/small-hack/argocd-apps.git
         path: zitadel/storage/{{ .zitadel_s3_provider }}/
-        targetRevision: main
+        targetRevision: fix/zitadel-s3

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -41,7 +41,7 @@ spec:
         chart: seaweedfs
         helm:
           releaseName: zitadel-seaweedfs
-          valuesObject:
+          values: |
             global:
               createClusterRole: true
               serviceAccountName: "zitadel-seaweedfs"

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -93,6 +93,26 @@ spec:
                 size: ""
                 storageClass: ""
                 hostPathPrefix: /storage
+              livenessProbe:
+                enabled: true
+                httpGet:
+                  path: /cluster/status
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 1
+                failureThreshold: 100
+                timeoutSeconds: 10
+              readinessProbe:
+                enabled: true
+                httpGet:
+                  path: /cluster/status
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 2
+                failureThreshold: 100
+                timeoutSeconds: 10
             volume:
               enabled: true
               port: 8080
@@ -108,6 +128,26 @@ spec:
                   type: "existingClaim"
                   claimName: "swfs-volume-data"
                   maxVolumes: 0
+              livenessProbe:
+                enabled: true
+                httpGet:
+                  path: /status
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 1
+                failureThreshold: 100
+                timeoutSeconds: 10
+              readinessProbe:
+                enabled: true
+                httpGet:
+                  path: /status
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 2
+                failureThreshold: 100
+                timeoutSeconds: 10
             filer:
               enabled: true
               replicas: 1
@@ -126,5 +166,25 @@ spec:
                 domainName: "{{ .seaweedfs_s3_endpoint }}"
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
+              livenessProbe:
+                enabled: true
+                httpGet:
+                  path: /
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 1
+                failureThreshold: 100
+                timeoutSeconds: 10
+              readinessProbe:
+                enabled: true
+                httpGet:
+                  path: /
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 2
+                successThreshold: 2
+                failureThreshold: 100
+                timeoutSeconds: 10
             s3:
               enabled: false

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -163,7 +163,7 @@ spec:
                 port: 8333
                 httpsPort: 0
                 allowEmptyFolder: false
-                domainName: "{{ .seaweedfs_s3_endpoint }}"
+                domainName: "{{ .zitadel_s3_endpoint }}"
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
                 createBuckets:

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -53,7 +53,7 @@ spec:
                   volumeRead: false
                   filerWrite: false
                   filerRead: false
-              serviceAccountName: "zitadel-seaweedfs"
+              serviceAccountName: "seaweedfs"
               certificates:
                 alphacrds: false
               monitoring:

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -41,7 +41,7 @@ spec:
         chart: seaweedfs
         helm:
           releaseName: zitadel-seaweedfs
-          values: |
+          valuesObject:
             global:
               createClusterRole: true
               imageName: chrislusf/seaweedfs

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -78,8 +78,6 @@ spec:
               grpcPort: 19333
               metricsPort: 9327
               ipBind: "0.0.0.0"
-              volumePreallocate: false
-              volumeSizeLimitMB: 1000
               # Prometheus push interval in seconds, default 15
               metricsIntervalSec: 15
               #  replication type is XYZ:
@@ -200,7 +198,7 @@ spec:
               minFreeSpacePercent: 7
 
               dataDirs:
-              - name: data1
+              - name: data
                 type: "existingClaim"
                 claimName: "swfs-volume-data"
                 maxVolumes: 0

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -78,6 +78,9 @@ spec:
               grpcPort: 19333
               metricsPort: 9327
               ipBind: "0.0.0.0"
+              loggingOverrideLevel: null
+              pulseSeconds: null
+              garbageThreshold: null
               # Prometheus push interval in seconds, default 15
               metricsIntervalSec: 15
               #  replication type is XYZ:
@@ -102,17 +105,17 @@ spec:
                 type: "existingClaim"
                 claimName: "swfs-master-data"
 
-              initContainers: ""
+              #initContainers: ""
 
-              extraVolumes: ""
-              extraVolumeMounts: ""
+              #extraVolumes: ""
+              #extraVolumeMounts: ""
 
               ## Set podManagementPolicy
-              podManagementPolicy: Parallel
+              #podManagementPolicy: Parallel
 
               # updatePartition is used to control a careful rolling update of SeaweedFS
               # masters.
-              updatePartition: 0
+              #updatePartition: 0
 
               # Affinity Settings
               # Commenting out or setting as empty the affinity variable, will allow
@@ -142,20 +145,20 @@ spec:
 
               # used to assign priority to master pods
               # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
+              #priorityClassName: ""
 
               # used to assign a service account.
               # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
+              #serviceAccountName: ""
 
               ingress:
                 enabled: false
 
-              extraEnvironmentVars:
-                WEED_MASTER_VOLUME_GROWTH_COPY_1: 7
-                WEED_MASTER_VOLUME_GROWTH_COPY_2: 6
-                WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
-                WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
+              #extraEnvironmentVars:
+              #  WEED_MASTER_VOLUME_GROWTH_COPY_1: 7
+              #  WEED_MASTER_VOLUME_GROWTH_COPY_2: 6
+              #  WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
+              #  WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
 
               # used to configure livenessProbe on master-server containers
               #
@@ -195,7 +198,7 @@ spec:
               fileSizeLimitMB: null
 
               # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
-              minFreeSpacePercent: 7
+              #minFreeSpacePercent: 7
 
               dataDirs:
               - name: data
@@ -203,34 +206,34 @@ spec:
                 claimName: "swfs-volume-data"
                 maxVolumes: 0
 
-              idx: ""
+              #idx: ""
 
               # limit background compaction or copying speed in mega bytes per second
-              compactionMBps: "50"
+              #compactionMBps: "50"
 
               # Directories to store data files. dir[,dir]... (default "/tmp")
-              dir: "/data"
+              #dir: "/data"
 
               # Directories to store index files. dir[,dir]... (default is the same as "dir")
-              dir_idx: null
+              #dir_idx: null
 
               # Maximum numbers of volumes, count[,count]...
               # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-              maxVolumes: "0"
+              #maxVolumes: "0"
 
               # Redirect moved or non-local volumes. (default proxy)
-              readMode: proxy
+              #readMode: proxy
 
               # Comma separated Ip addresses having write permission. No limit if empty.
-              whiteList: null
+              #whiteList: null
 
               # Adjust jpg orientation when uploading.
-              imagesFixOrientation: false
+              #imagesFixOrientation: false
 
-              initContainers: ""
+              #initContainers: ""
 
-              extraVolumes: ""
-              extraVolumeMounts: ""
+              #extraVolumes: ""
+              #extraVolumeMounts: ""
 
               ## Set podManagementPolicy
               podManagementPolicy: Parallel
@@ -263,11 +266,11 @@ spec:
 
               # used to assign priority to server pods
               # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
+              #priorityClassName: ""
 
               # used to assign a service account.
               # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
+              #serviceAccountName: ""
 
               # used to configure livenessProbe on volume-server containers
               #
@@ -298,39 +301,39 @@ spec:
             filer:
               enabled: true
               replicas: 1
-              loggingOverrideLevel: null
+              #loggingOverrideLevel: null
               # turn off directory listing
-              disableDirListing: false
+              #disableDirListing: false
               # split files larger than the limit, default 32
-              maxMB: null
+              #maxMB: null
               # encrypt data on volume servers
               encryptVolumeData: true
 
               # Whether proxy or redirect to volume server during file GET request
-              redirectOnRead: false
+              #redirectOnRead: false
 
               # Limit sub dir listing size (default 100000)
-              dirListLimit: 100000
+              #dirListLimit: 100000
 
               # Disable http request, only gRpc operations are allowed
-              disableHttp: false
+              #disableHttp: false
 
               # Settings for configuring stateful storage of filer pods.
               # enablePVC will create a pvc for filer for data persistence.
-              enablePVC: true
+              #enablePVC: true
 
               # storage should be set to the disk size of the attached volume.
-              storage: 25Gi
+              #storage: 25Gi
 
               # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
-              storageClass: local-path
+              #storageClass: local-path
 
               data:
                 type: "existingClaim"
                 claimName: "swfs-filer-data"
 
               ## Set podManagementPolicy
-              podManagementPolicy: Parallel
+              #podManagementPolicy: Parallel
 
               # Affinity Settings
               # Commenting out or setting as empty the affinity variable, will allow
@@ -347,45 +350,45 @@ spec:
 
               # updatePartition is used to control a careful rolling update of SeaweedFS
               # masters.
-              updatePartition: 0
+              #updatePartition: 0
 
               # Toleration Settings for server pods
               # This should be a multi-line string matching the Toleration array
               # in a PodSpec.
-              tolerations: ""
+              #tolerations: ""
 
               # nodeSelector labels for server pod assignment, formatted as a muli-line string.
               # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
               # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
+              #nodeSelector: |
+              #  beta.kubernetes.io/arch: amd64
               # nodeSelector: |
               #   sw-backend: "true"
 
               # used to assign priority to server pods
               # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              priorityClassName: ""
+              #priorityClassName: ""
 
               # used to assign a service account.
               # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              serviceAccountName: ""
+              #serviceAccountName: ""
 
               ingress:
                 enabled: false
 
               # extraEnvVars is a list of extra enviroment variables to set with the stateful set.
-              extraEnvironmentVars:
-                WEED_MYSQL_ENABLED: "false"
+              #extraEnvironmentVars:
+              #  WEED_MYSQL_ENABLED: "false"
 
                 # if you want to use leveldb2, then should enable "enablePVC". or you may lose your data.
-                WEED_LEVELDB2_ENABLED: "true"
+                #WEED_LEVELDB2_ENABLED: "true"
 
                 # with http DELETE, by default the filer would check whether a folder is empty.
                 # recursive_delete will delete all sub folders and files, similar to "rm -Rf"
-                WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
+                #WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
 
                 # directories under this folder will be automatically creating a separate bucket
-                WEED_FILER_BUCKETS_FOLDER: "/buckets"
+                #WEED_FILER_BUCKETS_FOLDER: "/buckets"
 
               # used to configure livenessProbe on filer containers
               #
@@ -416,8 +419,10 @@ spec:
               # this enables the filer and s3 which are both required to be deployed together
               s3:
                 enabled: true
-                allowEmptyFolder: false
+                port: 8333
+                httpsPort: 0
                 domainName: '{{ .zitadel_s3_endpoint }}'
+                allowEmptyFolder: false
                 # enable user & permission to s3 (need to inject to all services)
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
@@ -426,16 +431,16 @@ spec:
                     anonymousRead: false
             s3:
               enabled: false
-              ingress:
-                enabled: true
-                className: "nginx"
-                # host: false for "*" hostname
-                host: '{{ .zitadel_s3_endpoint }}'
-                # additional ingress annotations for the s3 endpoint
-                annotations:
-                  nginx.ingress.kubernetes.io/proxy-body-size: 1G
-                  cert-manager.io/cluster-issuer: '{{ .global_cluster_issuer }}'
-                tls:
-                  - secretName: zitadel-seaweedfs-tls
-                    hosts:
-                      - '{{ .zitadel_s3_endpoint }}'
+              #ingress:
+              #  enabled: true
+              #  className: "nginx"
+              #  host: false for "*" hostname
+              #  host: '{{ .zitadel_s3_endpoint }}'
+              #  additional ingress annotations for the s3 endpoint
+              #  annotations:
+              #    nginx.ingress.kubernetes.io/proxy-body-size: 1G
+              #    cert-manager.io/cluster-issuer: '{{ .global_cluster_issuer }}'
+              #  tls:
+              #    - secretName: zitadel-seaweedfs-tls
+              #      hosts:
+              #        - '{{ .zitadel_s3_endpoint }}'

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -163,7 +163,7 @@ spec:
                 port: 8333
                 httpsPort: 0
                 allowEmptyFolder: false
-                domainName: "{{ .zitadel_s3_endpoint }}"
+                domainName: '{{ .zitadel_s3_endpoint }}'
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
                 createBuckets:

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -44,8 +44,8 @@ spec:
           values: |
             global:
               createClusterRole: true
-              serviceAccountName: "zitadel-seaweedfs"
-              loggingLevel: 1
+              imageName: chrislusf/seaweedfs
+              imagePullPolicy: IfNotPresent
               enableSecurity: false
               securityConfig:
                 jwtSigning:
@@ -53,24 +53,22 @@ spec:
                   volumeRead: false
                   filerWrite: false
                   filerRead: false
+              serviceAccountName: "zitadel-seaweedfs"
               certificates:
                 alphacrds: false
               monitoring:
                 enabled: false
-
-              # if enabled will use global.replicationPlacment and override master & filer defaultReplicaPlacement config
+                gatewayHost: null
+                gatewayPort: null
               enableReplication: false
-
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               replicationPlacment: "001"
               extraEnvironmentVars:
                 WEED_CLUSTER_DEFAULT: "sw"
                 WEED_CLUSTER_SW_MASTER: "seaweedfs-master.seaweedfs:9333"
                 WEED_CLUSTER_SW_FILER: "seaweedfs-filer-client.seaweedfs:8888"
-
+            image:
+              registry: ""
+              repository: ""
             master:
               enabled: true
               replicas: 1
@@ -81,111 +79,20 @@ spec:
               loggingOverrideLevel: null
               pulseSeconds: null
               garbageThreshold: null
-              # Prometheus push interval in seconds, default 15
               metricsIntervalSec: 15
-              #  replication type is XYZ:
-              # X number of replica in other data centers
-              # Y number of replica in other racks in the same data center
-              # Z number of replica in other servers in the same rack
               defaultReplication: "000"
-
-              # Disable http request, only gRpc operations are allowed
               disableHttp: false
-
               config: |-
                 # Enter any extra configuration for master.toml here.
                 # It may be be a multi-line string.
-
-              # can use ANY storage-class , example with local-path-provisioner
-              #  data:
-              #    type: "persistentVolumeClaim"
-              #    size: "24Ti"
-              #    storageClass: "local-path-provisioner"
               data:
                 type: "existingClaim"
                 claimName: "swfs-master-data"
-
-              #initContainers: ""
-
-              #extraVolumes: ""
-              #extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              #podManagementPolicy: Parallel
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              #updatePartition: 0
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: master
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for master pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for master pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-                beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to master pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              #priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              #serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              #extraEnvironmentVars:
-              #  WEED_MASTER_VOLUME_GROWTH_COPY_1: 7
-              #  WEED_MASTER_VOLUME_GROWTH_COPY_2: 6
-              #  WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
-              #  WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
-
-              # used to configure livenessProbe on master-server containers
-              #
-              livenessProbe:
-                enabled: true
-                httpGet:
-                  path: /cluster/status
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 1
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # used to configure readinessProbe on master-server containers
-              #
-              readinessProbe:
-                enabled: true
-                httpGet:
-                  path: /cluster/status
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 2
-                failureThreshold: 100
-                timeoutSeconds: 10
-
+              logs:
+                type: "hostPath"
+                size: ""
+                storageClass: ""
+                hostPathPrefix: /storage
             volume:
               enabled: true
               port: 8080
@@ -193,254 +100,31 @@ spec:
               metricsPort: 9327
               ipBind: "0.0.0.0"
               replicas: 1
-
-              # limit file size to avoid out of memory, default 256mb
+              loggingOverrideLevel: null
               fileSizeLimitMB: null
-
-              # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
-              #minFreeSpacePercent: 7
-
+              minFreeSpacePercent: 7
               dataDirs:
-              - name: data
-                type: "existingClaim"
-                claimName: "swfs-volume-data"
-                maxVolumes: 0
-
-              #idx: ""
-
-              # limit background compaction or copying speed in mega bytes per second
-              #compactionMBps: "50"
-
-              # Directories to store data files. dir[,dir]... (default "/tmp")
-              #dir: "/data"
-
-              # Directories to store index files. dir[,dir]... (default is the same as "dir")
-              #dir_idx: null
-
-              # Maximum numbers of volumes, count[,count]...
-              # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-              #maxVolumes: "0"
-
-              # Redirect moved or non-local volumes. (default proxy)
-              #readMode: proxy
-
-              # Comma separated Ip addresses having write permission. No limit if empty.
-              #whiteList: null
-
-              # Adjust jpg orientation when uploading.
-              #imagesFixOrientation: false
-
-              #initContainers: ""
-
-              #extraVolumes: ""
-              #extraVolumeMounts: ""
-
-              ## Set podManagementPolicy
-              podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: volume
-                      topologyKey: kubernetes.io/hostname
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              nodeSelector: |
-               beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-volume: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              #priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              #serviceAccountName: ""
-
-              # used to configure livenessProbe on volume-server containers
-              #
-              livenessProbe:
-                enabled: true
-                httpGet:
-                  path: /status
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 1
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # used to configure readinessProbe on volume-server containers
-              #
-              readinessProbe:
-                enabled: true
-                httpGet:
-                  path: /status
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 2
-                failureThreshold: 100
-                timeoutSeconds: 10
-
+                - name: data
+                  type: "existingClaim"
+                  claimName: "swfs-volume-data"
+                  maxVolumes: 0
             filer:
               enabled: true
               replicas: 1
-              #loggingOverrideLevel: null
-              # turn off directory listing
-              #disableDirListing: false
-              # split files larger than the limit, default 32
-              #maxMB: null
-              # encrypt data on volume servers
-              encryptVolumeData: true
-
-              # Whether proxy or redirect to volume server during file GET request
-              #redirectOnRead: false
-
-              # Limit sub dir listing size (default 100000)
-              #dirListLimit: 100000
-
-              # Disable http request, only gRpc operations are allowed
-              #disableHttp: false
-
-              # Settings for configuring stateful storage of filer pods.
-              # enablePVC will create a pvc for filer for data persistence.
-              #enablePVC: true
-
-              # storage should be set to the disk size of the attached volume.
-              #storage: 25Gi
-
-              # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
-              #storageClass: local-path
-
+              port: 8888
+              grpcPort: 18888
+              metricsPort: 9327
+              encryptVolumeData: false
               data:
                 type: "existingClaim"
                 claimName: "swfs-filer-data"
-
-              ## Set podManagementPolicy
-              #podManagementPolicy: Parallel
-
-              # Affinity Settings
-              # Commenting out or setting as empty the affinity variable, will allow
-              # deployment to single node services such as Minikube
-              affinity: |
-                podAntiAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    - labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: seaweedfs
-                          app.kubernetes.io/instance: seaweedfs
-                          app.kubernetes.io/component: filer
-                      topologyKey: kubernetes.io/hostname
-
-              # updatePartition is used to control a careful rolling update of SeaweedFS
-              # masters.
-              #updatePartition: 0
-
-              # Toleration Settings for server pods
-              # This should be a multi-line string matching the Toleration array
-              # in a PodSpec.
-              #tolerations: ""
-
-              # nodeSelector labels for server pod assignment, formatted as a muli-line string.
-              # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-              # Example:
-              #nodeSelector: |
-              #  beta.kubernetes.io/arch: amd64
-              # nodeSelector: |
-              #   sw-backend: "true"
-
-              # used to assign priority to server pods
-              # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-              #priorityClassName: ""
-
-              # used to assign a service account.
-              # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-              #serviceAccountName: ""
-
-              ingress:
-                enabled: false
-
-              # extraEnvVars is a list of extra enviroment variables to set with the stateful set.
-              #extraEnvironmentVars:
-              #  WEED_MYSQL_ENABLED: "false"
-
-                # if you want to use leveldb2, then should enable "enablePVC". or you may lose your data.
-                #WEED_LEVELDB2_ENABLED: "true"
-
-                # with http DELETE, by default the filer would check whether a folder is empty.
-                # recursive_delete will delete all sub folders and files, similar to "rm -Rf"
-                #WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
-
-                # directories under this folder will be automatically creating a separate bucket
-                #WEED_FILER_BUCKETS_FOLDER: "/buckets"
-
-              # used to configure livenessProbe on filer containers
-              #
-              livenessProbe:
-                enabled: true
-                httpGet:
-                  path: /
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 1
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # used to configure readinessProbe on filer containers
-              #
-              readinessProbe:
-                enabled: true
-                httpGet:
-                  path: /
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 2
-                successThreshold: 2
-                failureThreshold: 100
-                timeoutSeconds: 10
-
-              # this enables the filer and s3 which are both required to be deployed together
               s3:
                 enabled: true
                 port: 8333
                 httpsPort: 0
-                domainName: '{{ .zitadel_s3_endpoint }}'
                 allowEmptyFolder: false
-                # enable user & permission to s3 (need to inject to all services)
+                domainName: "{{ .seaweedfs_s3_endpoint }}"
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
-                createBuckets:
-                  - name: zitadel-postgres
-                    anonymousRead: false
             s3:
               enabled: false
-              #ingress:
-              #  enabled: true
-              #  className: "nginx"
-              #  host: false for "*" hostname
-              #  host: '{{ .zitadel_s3_endpoint }}'
-              #  additional ingress annotations for the s3 endpoint
-              #  annotations:
-              #    nginx.ingress.kubernetes.io/proxy-body-size: 1G
-              #    cert-manager.io/cluster-issuer: '{{ .global_cluster_issuer }}'
-              #  tls:
-              #    - secretName: zitadel-seaweedfs-tls
-              #      hosts:
-              #        - '{{ .zitadel_s3_endpoint }}'

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -166,6 +166,9 @@ spec:
                 domainName: "{{ .seaweedfs_s3_endpoint }}"
                 enableAuth: true
                 existingConfigSecret: seaweedfs-s3-secret
+                createBuckets:
+                  - name: zitadel-postgres
+                    anonymousRead: false
               livenessProbe:
                 enabled: true
                 httpGet:

--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -53,7 +53,7 @@ spec:
                   volumeRead: false
                   filerWrite: false
                   filerRead: false
-              serviceAccountName: "seaweedfs"
+              serviceAccountName: "zitadel-seaweedfs"
               certificates:
                 alphacrds: false
               monitoring:
@@ -114,7 +114,7 @@ spec:
               port: 8888
               grpcPort: 18888
               metricsPort: 9327
-              encryptVolumeData: false
+              encryptVolumeData: true
               data:
                 type: "existingClaim"
                 claimName: "swfs-filer-data"


### PR DESCRIPTION
This propagates change from the seaweedfs app into: 
- zitadel 
- matrix
- mastodon
- nextcloud

Also adds a 'ServerSideApply' to CNPG operator to resolve issue with annotations being too large when a change is applied client-side