### PR TITLE
Add annotation to increase maximum body size in ingress

### DIFF
--- a/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
+++ b/zitadel/storage/seaweedfs/seaweedfs_argocd_appset.yaml
@@ -199,6 +199,7 @@ spec:
                 # additional ingress annotations for the s3 endpoint
                 annotations:
                   cert-manager.io/cluster-issuer: '{{ .global_cluster_issuer }}'
+                  nginx.ingress.kubernetes.io/proxy-body-size: "64m"
                 tls:
                   - secretName: zitadel-seaweedfs-tls
                     hosts:


### PR DESCRIPTION
WAL files cannot be backed up if they are over the size allowed by the ingress.

This PR adds an annotation to allow files up to 64m to pass through the ingress.

This could be alternatively resolved by pointing the backups at the internal DNS name of the seaweedfs service