### PR TITLE
attempt to use new helm chart version (0.6.0) for home-assistant and accept more default config options

### DIFF
--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -25,6 +25,9 @@ spec:
               - home_assistant_name
               - home_assistant_unit_system
               - home_assistant_temperature_unit
+              - home_assistant_latitude
+              - home_assistant_longitude
+              - home_assistant_elevation
               - home_assistant_toleration_key
               - home_assistant_toleration_operator
               - home_assistant_toleration_value
@@ -139,8 +142,11 @@ spec:
                   name: '{{ .home_assistant_name }}'
                   external_url: 'https://{{ .home_assistant_hostname }}'
                   time_zone: '{{ .global_time_zone }}'
-                  temperature_unit: {{ .home_assistant_temperature_unit }}
-                  unit_system: {{ .home_assistant_unit_system }}
+                  temperature_unit: '{{ .home_assistant_temperature_unit }}'
+                  unit_system: '{{ .home_assistant_unit_system }}'
+                  latitude: '{{ .home_assistant_latitude }}'
+                  longitude: '{{ .home_assistant_longitude }}'
+                  elevation: '{{ .home_assistant_elevation }}'
 
                 # reverse proxy for nginx stuff
                 http:

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -19,9 +19,10 @@ spec:
         input:
           parameters:
             secret_vars:
-              - home_assistant_hostname
               - global_cluster_issuer
               - global_time_zone
+              - home_assistant_hostname
+              - home_assistant_name
               - home_assistant_unit_system
               - home_assistant_temperature_unit
               - home_assistant_toleration_key
@@ -135,6 +136,7 @@ spec:
               configuration: |
                 # basic home assitant config stuff
                 homeassistant:
+                  name: '{{ .home_assistant_name }}'
                   external_url: 'https://{{ .home_assistant_hostname }}'
                   time_zone: '{{ .global_time_zone }}'
                   temperature_unit: {{ .home_assistant_temperature_unit }}
@@ -153,15 +155,15 @@ spec:
                 # enable configuration ui i think
                 config:
 
+                # include themes from another directory
+                frontend:
+                  themes: !include_dir_merge_named themes
+
                 # required for the automations UI to work
                 automation: !include automations.yaml
 
                 # required for the scenes UI to work
                 scene: !include scenes.yaml
-
-                # include themes from another directory
-                frontend:
-                  themes: !include_dir_merge_named themes
               existingThemesConfigMap: 'home-assistant-themes'
 
             livenessProbe:

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -99,11 +99,6 @@ spec:
                   type: CharDevice
                 name: usb
 
-              # for the basic themes we provide
-              - name: themes
-                configMap:
-                  name: home-assistant-themes
-
             extraVolumeMounts:
               # for an external USB device
               - mountPath: '{{ .home_assistant_usb_device_mount_path }}'
@@ -114,10 +109,6 @@ spec:
               - mountPath: '{{ .home_assistant_bluetooth_device_mount_path }}'
                 name: bluetooth
                 readOnly: true
-
-              # for the basic themes we provide
-              - name: themes
-                mountPath: /config/themes
 
             resources:
               limits:
@@ -171,6 +162,7 @@ spec:
                 # include themes from another directory
                 frontend:
                   themes: !include_dir_merge_named themes
+              existingThemesConfigMap: 'home-assistant-themes'
 
             livenessProbe:
               enabled: false

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -52,10 +52,12 @@ spec:
         automated:
           selfHeal: true
       source:
-        # https://github.com/small-hack/home-assistant-chart
-        repoURL: https://small-hack.github.io/home-assistant-chart
+        repoURL: https://github.com/small-hack/home-assistant-chart
+        targetRevision: touch-automations
+        path: charts/home-assistant/
+        # repoURL: https://small-hack.github.io/home-assistant-chart
+        # targetRevision: 0.6.0
         chart: home-assistant
-        targetRevision: 0.5.0
         helm:
           releaseName: home-assistant
           valuesObject:

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -56,8 +56,8 @@ spec:
         targetRevision: touch-automations
         path: charts/home-assistant/
         # repoURL: https://small-hack.github.io/home-assistant-chart
+        # chart: home-assistant
         # targetRevision: 0.6.0
-        chart: home-assistant
         helm:
           releaseName: home-assistant
           valuesObject:

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -39,7 +39,7 @@ spec:
               - home_assistant_bluetooth_device_index
   template:
     metadata:
-      name: home-assistant-app
+      name: home-assistant-helm
       annotations:
         argocd.argoproj.io/sync-wave: "2"
     spec:

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -56,12 +56,10 @@ spec:
         automated:
           selfHeal: true
       source:
-        repoURL: https://github.com/small-hack/home-assistant-chart
-        targetRevision: touch-automations
-        path: charts/home-assistant/
-        # repoURL: https://small-hack.github.io/home-assistant-chart
-        # chart: home-assistant
-        # targetRevision: 0.6.0
+        # repoURL: https://github.com/small-hack/home-assistant-chart
+        repoURL: https://small-hack.github.io/home-assistant-chart
+        chart: home-assistant
+        targetRevision: 0.6.0
         helm:
           releaseName: home-assistant
           valuesObject:


### PR DESCRIPTION
Pairs with https://github.com/small-hack/home-assistant-chart/pull/21

- Bumps helm chart version to `0.6.0`.

- We now accept the following secret vars:

  ```yaml
              - home_assistant_name
              - home_assistant_latitude
              - home_assistant_longitude
              - home_assistant_elevation
  ```

- fixes default themes to be passed in with new integrated helm chart values