### PR TITLE
adding an external secret to experiment with an initial admin user for home assistant

### DIFF
--- a/home-assistant/external_secrets/Chart.yaml
+++ b/home-assistant/external_secrets/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: home-assistant-eso-bitwarden-chart
+description: A Helm chart for Home Assistant External Secrets using the Bitwarden ESO provider on Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/home-assistant/external_secrets/README.md
+++ b/home-assistant/external_secrets/README.md
@@ -1,0 +1,3 @@
+# External Secrets For Home Assistant
+Includes:
+- admin credentials

--- a/home-assistant/external_secrets/templates/bitwarden/home-assistant-admin.yaml
+++ b/home-assistant/external_secrets/templates/bitwarden/home-assistant-admin.yaml
@@ -19,6 +19,8 @@ spec:
          {{ `{{ .password }}` }}
         ADMIN_LANGUAGE: |-
          {{ `{{ .language }}` }}
+        EXTERNAL_URL: |-
+         {{ `{{ .externalurl }}` }}
 
   data:
     - secretKey: username
@@ -64,4 +66,15 @@ spec:
         key: {{ .Values.bitwardenAdminCredentialsID }}
         # property within the bitwarden secret we want
         property: language
+
+    - secretKey: externalurl
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        # id of the bitwarden secret
+        key: {{ .Values.bitwardenAdminCredentialsID }}
+        # property within the bitwarden secret we want
+        property: externalurl
 {{- end }}

--- a/home-assistant/external_secrets/templates/bitwarden/home-assistant-admin.yaml
+++ b/home-assistant/external_secrets/templates/bitwarden/home-assistant-admin.yaml
@@ -1,0 +1,67 @@
+{{- if eq .Values.provider "bitwarden" }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-admin-creds
+spec:
+  target:
+    # Name of the kubernetes secret
+    name: home-assistant-credentials
+    deletionPolicy: Delete
+    template:
+      type: Opaque
+      data:
+        ADMIN_USERNAME: |-
+         {{ `{{ .username }}` }}
+        ADMIN_NAME: |-
+         {{ `{{ .name }}` }}
+        ADMIN_PASSWORD: |-
+         {{ `{{ .password }}` }}
+        ADMIN_LANGUAGE: |-
+         {{ `{{ .language }}` }}
+
+  data:
+    - secretKey: username
+      sourceRef:
+        storeRef:
+          name: bitwarden-login
+          kind: ClusterSecretStore
+      remoteRef:
+        # id of the bitwarden secret
+        key: {{ .Values.bitwardenAdminCredentialsID }}
+        # property within the bitwarden secret we want
+        property: username
+
+    - secretKey: name
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        # id of the bitwarden secret
+        key: {{ .Values.bitwardenAdminCredentialsID }}
+        # property within the bitwarden secret we want
+        property: name
+
+    - secretKey: password
+      sourceRef:
+        storeRef:
+          name: bitwarden-login
+          kind: ClusterSecretStore
+      remoteRef:
+        # id of the bitwarden secret
+        key: {{ .Values.bitwardenAdminCredentialsID }}
+        # property within the bitwarden secret we want
+        property: password
+
+    - secretKey: language
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        # id of the bitwarden secret
+        key: {{ .Values.bitwardenAdminCredentialsID }}
+        # property within the bitwarden secret we want
+        property: language
+{{- end }}

--- a/home-assistant/external_secrets/values.yaml
+++ b/home-assistant/external_secrets/values.yaml
@@ -2,4 +2,5 @@
 # other providers may be supported in the future
 provider: "true"
 
+# the item ID of the Bitwarden admin credentials
 bitwardenAdminCredentialsID: ""

--- a/home-assistant/external_secrets/values.yaml
+++ b/home-assistant/external_secrets/values.yaml
@@ -1,0 +1,5 @@
+## if this is not set to "bitwarden", we will not actually deploy any templates
+# other providers may be supported in the future
+provider: "true"
+
+bitwardenAdminCredentialsID: ""

--- a/home-assistant/home_assistant_argocd_appset.yaml
+++ b/home-assistant/home_assistant_argocd_appset.yaml
@@ -16,11 +16,17 @@ spec:
         input:
           parameters:
             secret_vars:
-              - home_assistant_hostname
               - global_cluster_issuer
               - global_time_zone
+              - home_assistant_hostname
+              - home_assistant_name
+              - home_assistant_currency
+              - home_assistant_country
               - home_assistant_unit_system
               - home_assistant_temperature_unit
+              - home_assistant_latitude
+              - home_assistant_longitude
+              - home_assistant_elevation
   template:
     metadata:
       name: home-assistant-app
@@ -40,7 +46,7 @@ spec:
         # https://github.com/small-hack/home-assistant-chart
         repoURL: https://small-hack.github.io/home-assistant-chart
         chart: home-assistant
-        targetRevision: 0.5.0
+        targetRevision: 0.7.2
         helm:
           releaseName: home-assistant
           valuesObject:
@@ -76,16 +82,22 @@ spec:
             extraVolumeMounts:
               - name: themes
                 mountPath: /config/themes
-            
+
             homeAssistant:
               # existingConfigMap: home-assistant
               configuration: |
                 # basic home assitant config stuff
                 homeassistant:
+                  name: '{{ .home_assistant_name }}'
+                  country: '{{ .home_assistant_country }}'
+                  currency: '{{ .home_assistant_currency }}'
+                  unit_system: '{{ .home_assistant_unit_system }}'
+                  temperature_unit: '{{ .home_assistant_temperature_unit }}'
+                  latitude: '{{ .home_assistant_latitude }}'
+                  longitude: '{{ .home_assistant_longitude }}'
+                  elevation: '{{ .home_assistant_elevation }}'
                   external_url: 'https://{{ .home_assistant_hostname }}'
                   time_zone: '{{ .global_time_zone }}'
-                  temperature_unit: {{ .home_assistant_temperature_unit }}
-                  unit_system: {{ .home_assistant_unit_system }}
 
                 # reverse proxy for nginx stuff
                 http:
@@ -102,7 +114,7 @@ spec:
 
                 # required for the automations UI to work
                 automation: !include automations.yaml
-                
+
                 # required for the scenes UI to work
                 scene: !include scenes.yaml
 

--- a/home-assistant/toleration_and_affinity/external_secrets_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/external_secrets_argocd_appset.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: home-assistant-bitwarden-eso
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  goTemplate: true
+  # generator allows us to source specific values from an external k8s secret
+  generators:
+    - plugin:
+        configMapRef:
+          name: secret-var-plugin-generator
+        input:
+          parameters:
+            secret_vars:
+              - global_external_secrets
+              - home_assistant_admin_credentials_bitwarden_id
+  template:
+    metadata:
+      name: home-assistant-bitwarden-eso
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    spec:
+      project: home-assistant
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: home-assistant
+      syncPolicy:
+        syncOptions:
+          - ApplyOutOfSyncOnly=true
+          - Retry=true
+        automated:
+          prune: true
+          selfHeal: true
+      source:
+        repoURL: 'https://github.com/small-hack/argocd-apps.git'
+        path: home-assistant/external_secrets/
+        targetRevision: home-assistant-initial-user
+        helm:
+          releaseName: home-assistant-bitwarden-eso
+          valuesObject:
+            provider: '{{ .global_external_secrets }}'
+            bitwardenAdminCredentialsID: '{{ .home_assistant_admin_credentials_bitwarden_id }}'

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -137,7 +137,7 @@ spec:
 
             homeAssistant:
               owner:
-                create: true
+                create: false
                 existingSecret: home-assistant-credentials
               configuration: |
                 # basic home assitant config stuff

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -56,10 +56,12 @@ spec:
         automated:
           selfHeal: true
       source:
-        # repoURL: https://github.com/small-hack/home-assistant-chart
-        repoURL: https://small-hack.github.io/home-assistant-chart
-        chart: home-assistant
-        targetRevision: 0.6.0
+        repoURL: https://github.com/small-hack/home-assistant-chart
+        path: charts/home-assistant/
+        targetRevision: create-initial-user
+        # repoURL: https://small-hack.github.io/home-assistant-chart
+        # chart: home-assistant
+        # targetRevision: 0.7.0
         helm:
           releaseName: home-assistant
           valuesObject:
@@ -134,6 +136,9 @@ spec:
                           - '{{ .home_assistant_affinity_value }}'
 
             homeAssistant:
+              owner:
+                create: true
+                existingSecret: home-assistant-credentials
               configuration: |
                 # basic home assitant config stuff
                 homeassistant:

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -137,7 +137,7 @@ spec:
 
             homeAssistant:
               owner:
-                create: false
+                create: true
                 existingSecret: home-assistant-credentials
               configuration: |
                 # basic home assitant config stuff

--- a/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity/home_assistant_argocd_appset.yaml
@@ -23,6 +23,8 @@ spec:
               - global_time_zone
               - home_assistant_hostname
               - home_assistant_name
+              - home_assistant_currency
+              - home_assistant_country
               - home_assistant_unit_system
               - home_assistant_temperature_unit
               - home_assistant_latitude
@@ -56,12 +58,10 @@ spec:
         automated:
           selfHeal: true
       source:
-        repoURL: https://github.com/small-hack/home-assistant-chart
-        path: charts/home-assistant/
-        targetRevision: create-initial-user
-        # repoURL: https://small-hack.github.io/home-assistant-chart
-        # chart: home-assistant
-        # targetRevision: 0.7.0
+        # repoURL: https://github.com/small-hack/home-assistant-chart
+        repoURL: https://small-hack.github.io/home-assistant-chart
+        chart: home-assistant
+        targetRevision: 0.7.2
         helm:
           releaseName: home-assistant
           valuesObject:
@@ -143,13 +143,15 @@ spec:
                 # basic home assitant config stuff
                 homeassistant:
                   name: '{{ .home_assistant_name }}'
-                  external_url: 'https://{{ .home_assistant_hostname }}'
-                  time_zone: '{{ .global_time_zone }}'
-                  temperature_unit: '{{ .home_assistant_temperature_unit }}'
+                  country: '{{ .home_assistant_country }}'
+                  currency: '{{ .home_assistant_currency }}'
                   unit_system: '{{ .home_assistant_unit_system }}'
+                  temperature_unit: '{{ .home_assistant_temperature_unit }}'
                   latitude: '{{ .home_assistant_latitude }}'
                   longitude: '{{ .home_assistant_longitude }}'
                   elevation: '{{ .home_assistant_elevation }}'
+                  external_url: 'https://{{ .home_assistant_hostname }}'
+                  time_zone: '{{ .global_time_zone }}'
 
                 # reverse proxy for nginx stuff
                 http:


### PR DESCRIPTION
goes with https://github.com/small-hack/home-assistant-chart/pull/22 for this release:
https://github.com/small-hack/home-assistant-chart/releases/tag/home-assistant-0.7.2

- Adds an external secret for creating a new user
- enables new user
- sets all defaults for home assistant basic config