### PR TITLE
WAF exemption from 942100 for prometheus and loki

### DIFF
--- a/ingress-nginx/plugins/plugins-configmap.yaml
+++ b/ingress-nginx/plugins/plugins-configmap.yaml
@@ -37,14 +37,14 @@ data:
       phase:1,\
       pass,\
       nolog,\
-      ctl:ruleRemoveById=933210"
+      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100""
 
     SecRule REQUEST_URI "@beginsWith /api/ds/query?ds_type=prometheus" \
       "id:20014,\
       phase:1,\
       pass,\
       nolog,\
-      ctl:ruleRemoveById=933210"
+    ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100"
   postgres-s3-rule-exclusions-before.conf: |-
     # ---------------------------------------------
     # allow postgresql to upload wal archives to s3

--- a/ingress-nginx/plugins/plugins-configmap.yaml
+++ b/ingress-nginx/plugins/plugins-configmap.yaml
@@ -37,7 +37,7 @@ data:
       phase:1,\
       pass,\
       nolog,\
-      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100""
+      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100"
 
     SecRule REQUEST_URI "@beginsWith /api/ds/query?ds_type=prometheus" \
       "id:20014,\

--- a/ingress-nginx/plugins/plugins-configmap.yaml
+++ b/ingress-nginx/plugins/plugins-configmap.yaml
@@ -44,7 +44,7 @@ data:
       phase:1,\
       pass,\
       nolog,\
-    ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100"
+      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100"
   postgres-s3-rule-exclusions-before.conf: |-
     # ---------------------------------------------
     # allow postgresql to upload wal archives to s3


### PR DESCRIPTION
Prevents the following when refreshing a grafana dashboard:

> Tue Jul  2 19:58:00 2024 Severity: 2 Rule: 942100 Reason: SQL Injection Attack Detected via libinjection Event: request for 10.42.0.11:443/api/ds/query?ds_type=prometheus&requestId=Q130 from 192.168.1.1

<img width="831" alt="Screenshot 2024-07-02 at 20 03 08" src="https://github.com/small-hack/argocd-apps/assets/84841307/97d3e3df-71c6-446a-91e0-aa1b46a47f8d">
