### PR TITLE
add waf exemption for 932110 in loki & prom

### DIFF
--- a/ingress-nginx/plugins/plugins-configmap.yaml
+++ b/ingress-nginx/plugins/plugins-configmap.yaml
@@ -37,14 +37,14 @@ data:
       phase:1,\
       pass,\
       nolog,\
-      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100"
+      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100,ctl:ruleRemoveById=932110"
 
     SecRule REQUEST_URI "@beginsWith /api/ds/query?ds_type=prometheus" \
       "id:20014,\
       phase:1,\
       pass,\
       nolog,\
-      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100"
+      ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100,ctl:ruleRemoveById=932110"
   postgres-s3-rule-exclusions-before.conf: |-
     # ---------------------------------------------
     # allow postgresql to upload wal archives to s3


### PR DESCRIPTION
Prevents the following when accessing `kubernetes-compute-resources-cluster` dashboard:

> Tue Jul  2 20:44:45 2024 Severity: 2 Rule: 932110 Reason: Remote Command Execution: Windows Command Injection Event: request for 10.42.0.17:443/api/ds/query?ds_type=prometheus&requestId=mixed-0-Q892 from 192.168.1.1

<img width="951" alt="Screenshot 2024-07-02 at 20 49 39" src="https://github.com/small-hack/argocd-apps/assets/84841307/843fe12d-6ad0-45df-bfc7-c05b4f3210bf">
