### PR TITLE
allow Kubernetes grafana dashboards via modsecurity rule exceptions

### DIFF
--- a/ingress-nginx/plugins/plugins-configmap.yaml
+++ b/ingress-nginx/plugins/plugins-configmap.yaml
@@ -45,6 +45,13 @@ data:
       pass,\
       nolog,\
       ctl:ruleRemoveById=933210,ctl:ruleRemoveById=942100,ctl:ruleRemoveById=932110"
+
+    SecRule REQUEST_URI "@beginsWith /api/datasources/uid/prometheus/resources/api/v1/label" \
+      "id:20017,\
+      phase:1,\
+      pass,\
+      nolog,\
+      ctl:ruleRemoveById=932110"
   postgres-s3-rule-exclusions-before.conf: |-
     # ---------------------------------------------
     # allow postgresql to upload wal archives to s3


### PR DESCRIPTION
This is to prevent this in the logs:

```logtalk
2024/07/03 08:40:24 [error] 197#197: *21581 [client 192.168.1.1] ModSecurity: Access denied with code 403 (phase 2). Matched "Operator `Ge' with parameter `5' against variable `TX:ANOMALY_SCORE' (Value: `5' ) [file "/etc/nginx/owasp-modsecurity-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "81"] [id "949110"] [rev ""] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [data ""] [severity "2"] [ver "OWASP_CRS/3.3.5"] [maturity "0"] [accuracy "0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "10.42.0.44"] [uri "/api/datasources/uid/prometheus/resources/api/v1/label/node/values"] [unique_id "171998882410.415579"] [ref ""], client: 192.168.1.1, server: grafana.mydomain.com, request: "GET /api/datasources/uid/prometheus/resources/api/v1/label/node/values?match%5B%5D=kube_node_info%7Bcluster%3D%22%22%7D&start=1719985223&end=1719988823 HTTP/2.0", host: "grafana.mydomain.com", referrer: "https://grafana.mydomain.com/d/200ac8fdbfbb74b39aff88118e4d1c2c/kubernetes-compute-resources-node-pods?orgId=1&refresh=10s"
```