### PR TITLE
Update home_assistant_argocd_appset.yaml - enabled circadian rythm lighting

### DIFF
--- a/home-assistant/toleration_and_affinity_app_of_apps/home_assistant_argocd_appset.yaml
+++ b/home-assistant/toleration_and_affinity_app_of_apps/home_assistant_argocd_appset.yaml
@@ -163,6 +163,9 @@ spec:
                 # Discover some mobile devices automatically
                 mobile_app:
 
+                # enable circadian rythim lighting
+                circadian_lighting:
+
                 # enable configuration ui i think
                 config:
 


### PR DESCRIPTION
adjust lights according to time of day