### PR TITLE
increase valkey resources in mastodon

### DIFF
--- a/mastodon/small-hack/app_of_apps/valkey_argocd_appset.yaml
+++ b/mastodon/small-hack/app_of_apps/valkey_argocd_appset.yaml
@@ -76,3 +76,7 @@ spec:
             metrics:
               # we use a grafana exporter that logs into valkey directly
               enabled: false
+            
+            # definitions of presets https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+            # defult is "nano"
+            resourcesPreset: "small"


### PR DESCRIPTION
Bitnami uses a weird preset list of resources sizes for all of their charts and defaults most apps to "nano" which is reallllly tiny. This PR bumps it to small since we were getting cpu throttling on the valkey instance with just 2 users doing some light browsing.

Nano:

```
  "nano" (dict 
      "requests" (dict "cpu" "100m" "memory" "128Mi" "ephemeral-storage" "50Mi")
      "limits" (dict "cpu" "150m" "memory" "192Mi" "ephemeral-storage" "2Gi")
```

Small:

```
  "small" (dict 
      "requests" (dict "cpu" "500m" "memory" "512Mi" "ephemeral-storage" "50Mi")
      "limits" (dict "cpu" "750m" "memory" "768Mi" "ephemeral-storage" "2Gi")
   )
```

Source:
- https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15