### PR TITLE
add a node selector to ingress-nginx that tragets nodes labled as ingress-ready=true

### DIFF
--- a/ingress-nginx/ingress-nginx_argocd_appset.yaml
+++ b/ingress-nginx/ingress-nginx_argocd_appset.yaml
@@ -71,6 +71,10 @@ spec:
                     cpu: 100m
                     memory: 128Mi
 
+              nodeSelector:
+                kubernetes.io/os: linux
+                ingress-ready: "true"
+
               config:
                 annotations-risk-level: Critical
                 # set log format to json


### PR DESCRIPTION
we already tell users to apply this label when using ingress-nginx on K3s:

From our docs:

```yaml
k8s_distros:
  k3s:
    enabled: false
    k3s_yaml:
      # if you enable MetalLB, we automatically add servicelb to the disable list
      # enables encryption at rest for Kubernetes secrets
      secrets-encryption: true
      # disables traefik so we can enable ingress-nginx, remove if you're using traefik
      disable:
      - "traefik"
      node-label:
      - "ingress-ready=true"
      kubelet-arg:
      - "max-pods=150"
```